### PR TITLE
fix: set correct version of Wendy dependency, fix typos in docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-ios
     
+    - name: Update CocoaPods repo to assert dependencies latest versions reachable 
+      run: pod repo update
     - run: pod lib lint --allow-warnings
 
   deployment:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the SDK by adding a new entry to your app’s `Podfile`:
 pod 'Wendy-Reader-CoreData', '~> version-here'
 ```
 
-(replace `version-here` with  [!\[Version]()[image-6][3]][7][4])
+Replace `version-here` with [![Version][image-1]][2]. 
 
 Next, add the reader to Wendy: 
 
@@ -20,6 +20,7 @@ Next, add the reader to Wendy:
 import Wendy
 import WendyReaderCoreData
 
+Wendy.setup(...)
 Wendy.shared.addReader(WendyCoreDataQueueReader())
 ```
 
@@ -28,5 +29,6 @@ Done!
 The next time that Wendy executes, it will read tasks from CoreData as well as other data stores. 
 
 [1]:	https://github.com/levibostian/Wendy-iOS/
-[3]:	https://img.shields.io/cocoapods/v/Wendy-Reader-CoreData.svg?style=flat
-[4]:	https://github.com/levibostian/Wendy-iOS-Reader-CoreData
+[2]:	https://github.com/levibostian/Wendy-iOS-Reader-CoreData
+
+[image-1]:	https://img.shields.io/cocoapods/v/Wendy-Reader-CoreData.svg?style=flat

--- a/Wendy-Reader-CoreData.podspec
+++ b/Wendy-Reader-CoreData.podspec
@@ -41,7 +41,7 @@ Note: It's highly recommended to read the documentation before use. This project
 #    // TODO run bash script to install templates.
 #  end
 
-  s.dependency 'Wendy', '~> 5.1'
+  s.dependency 'Wendy', '~> 6.0'
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   s.frameworks = 'CoreData'


### PR DESCRIPTION
This pod is actually meant to be used on Wendy v6. Since v6 is the first version of Wendy without CoreData in it.

commit-id:ac987af1